### PR TITLE
Explicitly require 'forwardable' from stdlib

### DIFF
--- a/lib/timers.rb
+++ b/lib/timers.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'forwardable'
 require 'timers/version'
 
 # Low precision timers implemented in pure Ruby


### PR DESCRIPTION
The specs didn't catch this, because rspec requires it already.

```
$ ruby -r ./lib/timers.rb -e "puts 'Hello world'"
/home/nick/src/vendor/timers/lib/timers.rb:8:in `<class:Timers>': uninitialized constant Timers::Forwardable (NameError)
        from /home/nick/src/vendor/timers/lib/timers.rb:6:in `<top (required)>'
        from /home/nick/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /home/nick/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
```
