### PR TITLE
Use RBTree directly instead of SortedSet (which is wrapper to rbtree in best case)

### DIFF
--- a/timers.gemspec
+++ b/timers.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
+  gem.add_dependency 'rbtree'
 end


### PR DESCRIPTION
SortedSet uses rbtree when available, but fallsback to slow implementation
when rbtree is not available.
Use rbtree directly to ensure stable performance.
