### PR TITLE
Timers#wait fails if overdue

### DIFF
--- a/lib/timers.rb
+++ b/lib/timers.rb
@@ -33,7 +33,8 @@ class Timers
   def wait_interval(now = Time.now)
     timer = @timers.first
     return unless timer
-    timer.time - now
+    interval = timer.time - now
+    interval > 0 ? interval : 0
   end
 
   # Fire all timers that are ready

--- a/spec/timers_spec.rb
+++ b/spec/timers_spec.rb
@@ -16,11 +16,23 @@ describe Timers do
     (Time.now - started_at).should be_within(Q).of interval
   end
 
+  it "fires instantly when next timer is in the past" do
+    fired = false
+    subject.after(Q) { fired = true }
+    sleep(Q * 2)
+    subject.wait
+
+    fired.should be_true
+  end
+
   it "calculates the interval until the next timer should fire" do
     interval = 0.1
 
     subject.after(interval)
     subject.wait_interval.should be_within(Q).of interval
+
+    sleep(interval)
+    subject.wait_interval.should be(0)
   end
 
   it "fires timers in the correct order" do


### PR DESCRIPTION
Because `#wait_interval` returns a negative number `sleep` fails with `ArgumentError: time interval must be positive`.
