### PR TITLE
Call out all authors in AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,14 @@
+# The Celluloid timers gem is beamed directly to you from the minds of...
+
+- Tony Arcieri <bascule@gmail.com>
+- Jeremy Hinegardner
+- Sean Gregory
+- Chuck Remes
+- Utenmiki
+- Ron Evans
+- Larry Lv
+- Bruno Enten
+- Jesse Cooke
+- Nicholas Evans
+- Dimitrij Denissenko
+- Ryan LeCompte

--- a/README.md
+++ b/README.md
@@ -90,5 +90,7 @@ timers.continue
 License
 -------
 
-Copyright (c) 2014 Tony Arcieri. Distributed under the MIT License. See
-LICENSE for further details.
+Copyright (c) 2014 Celluloid timers project developers (given in the file
+AUTHORS.md).
+
+Distributed under the MIT License. See LICENSE file for further details.


### PR DESCRIPTION
This replaces the single author (i.e. yours truly) copyright clause with one that refers to a list of all project authors given in the AUTHORS.md file

cc @ioquatix 
