### PR TITLE
Require 'set' before referring to SortedSet

### DIFF
--- a/lib/timers.rb
+++ b/lib/timers.rb
@@ -1,6 +1,7 @@
 
 # Workaround for thread safety issues in SortedSet initialization
 # See: https://github.com/celluloid/timers/issues/20
+require 'set'
 SortedSet.new
 
 require 'timers/version'


### PR DESCRIPTION
If 'set' is not required before requiring 'timers', an exception is raised due
to SortedSet not being defined.
