### PR TITLE
Added gem install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ single timeout but you want to run multiple timers on top of it. An example of
 such a library is [nio4r](https://github.com/celluloid/nio4r), a cross-platform
 Ruby library for using system calls like epoll and kqueue.
 
+Installation
+------------
+
+Add this line to your Gemfile:
+```ruby
+gem 'timers', :git => 'git://github.com/celluloid/timers.git'
+```
+
 Usage
 -----
 


### PR DESCRIPTION
There seems to be another gem called "timers" that gets installed if you don't specify the Git source.
