### PR TITLE
Fix issue #41: Hang up when "mathn" is required

### DIFF
--- a/lib/timers/events.rb
+++ b/lib/timers/events.rb
@@ -100,7 +100,7 @@ module Timers
     # a is sorted in descending order.
     def bisect_left(a, e, l = 0, u = a.length)
       while l < u
-        m = l + (u-l)/2
+        m = l + (u-l).div(2)
         
         if a[m] > e
           l = m+1


### PR DESCRIPTION
The following code buzzed:

``` ruby
require 'timers'
require 'mathn'

timers = Timers::Group.new
t = timers.after(5) { puts "OK!" }
sleep(1)
t.reset
timers.wait()
```
