### PR TITLE
#inspect should not output negative object IDs.

### DIFF
--- a/lib/timers/timer.rb
+++ b/lib/timers/timer.rb
@@ -109,7 +109,7 @@ module Timers
 
     # Inspect a timer
     def inspect
-      str = "#<Timers::Timer:#{object_id.to_s(16)} ".dup
+      str = "#{to_s[0..-2]} ".dup
 
       if @offset
         str << if fires_in >= 0

--- a/spec/timers/group_spec.rb
+++ b/spec/timers/group_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Timers::Group do
       timer = subject.after(TIMER_QUANTUM * 5) { fired = true }
       timer.pause
       expect(fired).not_to be true
-      expect(timer.inspect).to match(/\A#<Timers::Timer:[\da-f]+ fires in [-\.\de]+ seconds>\Z/)
+      expect(timer.inspect).to match(/\A#<Timers::Timer:0x[\da-f]+ fires in [-\.\de]+ seconds>\Z/)
     end
 
     it "after firing" do
@@ -216,7 +216,7 @@ RSpec.describe Timers::Group do
       subject.wait
 
       expect(fired).to be true
-      expect(timer.inspect).to match(/\A#<Timers::Timer:[\da-f]+ fired [-\.\de]+ seconds ago>\Z/)
+      expect(timer.inspect).to match(/\A#<Timers::Timer:0x[\da-f]+ fired [-\.\de]+ seconds ago>\Z/)
     end
 
     it "recurring firing" do
@@ -225,7 +225,7 @@ RSpec.describe Timers::Group do
 
       subject.wait
       expect(result).not_to be_empty
-      regex = /\A#<Timers::Timer:[\da-f]+ fires in [-\.\de]+ seconds, recurs every #{format("%0.2f", TIMER_QUANTUM)}>\Z/
+      regex = /\A#<Timers::Timer:0x[\da-f]+ fires in [-\.\de]+ seconds, recurs every #{format("%0.2f", TIMER_QUANTUM)}>\Z/
       expect(timer.inspect).to match(regex)
     end
   end


### PR DESCRIPTION
It might happen that object ID is 'negative', since Ruby tries to avoid Bignums:

https://bugs.ruby-lang.org/issues/13397

This might be the test failures, which were recently reported by Fedora CI [[1]]:

~~~
  1) Timers::Group Timer inspection after firing
     Failure/Error: expect(timer.inspect).to match(/\A#<Timers::Timer:[\da-f]+ fired [-\.\de]+ seconds ago>\Z/)
       expected "#<Timers::Timer:-3ff0ad00 fired 0.0001704610000000037 seconds ago>" to match /\A#<Timers::Timer:[\da-f]+ fired [-\.\de]+ seconds ago>\Z/
       Diff:
       @@ -1,2 +1,2 @@
       -/\A#<Timers::Timer:[\da-f]+ fired [-\.\de]+ seconds ago>\Z/
       +"#<Timers::Timer:-3ff0ad00 fired 0.0001704610000000037 seconds ago>"
     # /usr/share/gems/gems/rspec-support-3.6.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /usr/share/gems/gems/rspec-support-3.6.0/lib/rspec/support.rb:96:in `notify_failure'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/fail_with.rb:35:in `fail_with'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/group_spec.rb:219:in `block (3 levels) in <top (required)>'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:254:in `instance_exec'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:254:in `block in run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:500:in `block in with_around_and_singleton_context_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:457:in `block in with_around_example_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:464:in `block in run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:464:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:457:in `with_around_example_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:500:in `with_around_and_singleton_context_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:251:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:623:in `map'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:589:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `block in run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `map'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `block (3 levels) in run_specs'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `map'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `block (2 levels) in run_specs'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/configuration.rb:1894:in `with_suite_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/reporter.rb:79:in `report'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:112:in `run_specs'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:87:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:71:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:45:in `invoke'
     # /usr/share/gems/gems/rspec-core-3.6.0/exe/rspec:4:in `<top (required)>'
     # /usr/bin/rspec:22:in `load'
     # /usr/bin/rspec:22:in `<main>'
  2) Timers::Group Timer inspection before firing
     Failure/Error: expect(timer.inspect).to match(/\A#<Timers::Timer:[\da-f]+ fires in [-\.\de]+ seconds>\Z/)
       expected "#<Timers::Timer:-3ff9674c fires in 0.24982855900000003 seconds>" to match /\A#<Timers::Timer:[\da-f]+ fires in [-\.\de]+ seconds>\Z/
       Diff:
       @@ -1,2 +1,2 @@
       -/\A#<Timers::Timer:[\da-f]+ fires in [-\.\de]+ seconds>\Z/
       +"#<Timers::Timer:-3ff9674c fires in 0.24982855900000003 seconds>"
     # /usr/share/gems/gems/rspec-support-3.6.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /usr/share/gems/gems/rspec-support-3.6.0/lib/rspec/support.rb:96:in `notify_failure'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/fail_with.rb:35:in `fail_with'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/group_spec.rb:209:in `block (3 levels) in <top (required)>'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:254:in `instance_exec'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:254:in `block in run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:500:in `block in with_around_and_singleton_context_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:457:in `block in with_around_example_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:464:in `block in run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:464:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:457:in `with_around_example_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:500:in `with_around_and_singleton_context_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:251:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:623:in `map'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:589:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `block in run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `map'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `block (3 levels) in run_specs'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `map'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `block (2 levels) in run_specs'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/configuration.rb:1894:in `with_suite_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/reporter.rb:79:in `report'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:112:in `run_specs'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:87:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:71:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:45:in `invoke'
     # /usr/share/gems/gems/rspec-core-3.6.0/exe/rspec:4:in `<top (required)>'
     # /usr/bin/rspec:22:in `load'
     # /usr/bin/rspec:22:in `<main>'
  3) Timers::Group Timer inspection recurring firing
     Failure/Error: expect(timer.inspect).to match(/\A#<Timers::Timer:[\da-f]+ fires in [-\.\de]+ seconds, recurs every #{sprintf("%0.2f", TIMER_QUANTUM)}>\Z/)
       expected "#<Timers::Timer:-3ff9bf90 fires in 0.049652778 seconds, recurs every 0.05>" to match /\A#<Timers::Timer:[\da-f]+ fires in [-\.\de]+ seconds, recurs every 0.05>\Z/
       Diff:
       @@ -1,2 +1,2 @@
       -/\A#<Timers::Timer:[\da-f]+ fires in [-\.\de]+ seconds, recurs every 0.05>\Z/
       +"#<Timers::Timer:-3ff9bf90 fires in 0.049652778 seconds, recurs every 0.05>"
     # /usr/share/gems/gems/rspec-support-3.6.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /usr/share/gems/gems/rspec-support-3.6.0/lib/rspec/support.rb:96:in `notify_failure'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/fail_with.rb:35:in `fail_with'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /usr/share/gems/gems/rspec-expectations-3.6.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/group_spec.rb:228:in `block (3 levels) in <top (required)>'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:254:in `instance_exec'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:254:in `block in run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:500:in `block in with_around_and_singleton_context_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:457:in `block in with_around_example_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:464:in `block in run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:464:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:457:in `with_around_example_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:500:in `with_around_and_singleton_context_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:251:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:623:in `map'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:589:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `block in run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `map'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `block (3 levels) in run_specs'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `map'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `block (2 levels) in run_specs'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/configuration.rb:1894:in `with_suite_hooks'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/reporter.rb:79:in `report'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:112:in `run_specs'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:87:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:71:in `run'
     # /usr/share/gems/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:45:in `invoke'
     # /usr/share/gems/gems/rspec-core-3.6.0/exe/rspec:4:in `<top (required)>'
     # /usr/bin/rspec:22:in `load'
     # /usr/bin/rspec:22:in `<main>'
~~~

[1]: https://apps.fedoraproject.org/koschei/build/3002940