### PR TITLE
Latest JRuby in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.1.10
   - 2.2.6
   - 2.3.3
-  - jruby-9.1.13.0
+  - jruby-9.1.14.0
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/11/08/jruby-9-1-14-0.html