### PR TITLE
Priority queue using Heap instead of Array

### DIFF
--- a/lib/timers/events.rb
+++ b/lib/timers/events.rb
@@ -24,10 +24,12 @@ require_relative "timer"
 require_relative "priority_heap"
 
 module Timers
-	# Maintains an ordered list of events, which can be cancelled.
+	# Maintains a PriorityHeap of events ordered on time, which can be cancelled.
 	class Events
 		# Represents a cancellable handle for a specific timer event.
 		class Handle
+			include Comparable
+
 			def initialize(time, callback)
 				@time = time
 				@callback = callback
@@ -48,21 +50,13 @@ module Timers
 				@callback.nil?
 			end
 
-			def < other
-				@time < other.to_f
-			end
-			
-			def > other
-				@time > other.to_f
+			def <=> other
+				@time <=> other.time
 			end
 
-			def >= other
-				@time >= other.to_f
-			end
-
-			def to_f
-				@time
-			end
+			# def to_f
+			# 	@time
+			# end
 
 			# Fire the callback if not cancelled with the given time parameter.
 			def fire(time)

--- a/lib/timers/priority_heap.rb
+++ b/lib/timers/priority_heap.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Timers
   # A priority queue implementation using a standard binary minheap. It uses straight comparison
   # of its contents to determine priority. This works because a Handle from Timers::Events implements
@@ -18,9 +20,16 @@ module Timers
       @contents[0]
     end
 
+    # Returns the number of elements in the heap
+    def size
+      @contents.size
+    end
+
     # Returns the earliest timer if the heap is non-empty and removes it from the heap.
     # Returns nil if the heap is empty. (and doesn't change the heap in that case)
     def pop
+      return nil if @contents.empty?
+      return @contents.pop if @contents.size == 1 # no need to do heap trickery in this case
       min = @contents[0]
       last = @contents.pop
       @contents[0] = last
@@ -46,7 +55,7 @@ module Timers
 
     def bubble_up(index)
       parent_index = (index - 1) / 2 # watch out, integer division!
-      while index > 0 && @contents[index] > @contents[parent_index]
+      while index > 0 && @contents[index] < @contents[parent_index]
         # if the node has a smaller value than its parent, swap these nodes
         # to uphold the minheap invariant and update the index of the 'current'
         # node. If the node is already at index 0, we can also stop because that
@@ -74,7 +83,7 @@ module Timers
           # node only has a left child
           least_valued_child_node = left_child_value
           least_valued_child_index = left_child_index
-        elsif right_child_value < left_child_value
+        elsif right_child_value > left_child_value
           least_valued_child_node = left_child_value
           least_valued_child_index = left_child_index
         else

--- a/lib/timers/priority_heap.rb
+++ b/lib/timers/priority_heap.rb
@@ -16,7 +16,7 @@ module Timers
     end
 
     # Returns the earliest timer or nil if the heap is empty.
-    def first
+    def peek
       @contents[0]
     end
 
@@ -39,7 +39,7 @@ module Timers
 
     # Inserts a new timer into the heap, then rearranges elements until the heap invariant
     # is true again.
-    def insert(element)
+    def push(element)
       @contents.push(element)
       bubble_up(@contents.size - 1)
       self

--- a/lib/timers/priority_heap.rb
+++ b/lib/timers/priority_heap.rb
@@ -1,0 +1,97 @@
+module Timers
+  # A priority queue implementation using a standard binary minheap. It uses straight comparison
+  # of its contents to determine priority. This works because a Handle from Timers::Events implements
+  # the '<' operation by comparing the expiry time.
+
+  # See https://en.wikipedia.org/wiki/Binary_heap for explanations of the main methods.
+
+  class PriorityHeap
+    def initialize
+      # The heap is represented with an array containing a binary tree. See
+      # https://en.wikipedia.org/wiki/Binary_heap#Heap_implementation for how this array
+      # is built up.
+      @contents = []
+    end
+
+    # Returns the earliest timer or nil if the heap is empty.
+    def first
+      @contents[0]
+    end
+
+    # Returns the earliest timer if the heap is non-empty and removes it from the heap.
+    # Returns nil if the heap is empty. (and doesn't change the heap in that case)
+    def pop
+      min = @contents[0]
+      last = @contents.pop
+      @contents[0] = last
+      bubble_down(0)
+      min
+    end
+
+    # Inserts a new timer into the heap, then rearranges elements until the heap invariant
+    # is true again.
+    def insert(element)
+      @contents.push(element)
+      bubble_up(@contents.size - 1)
+      self
+    end
+
+    private
+
+    def swap(index1, index2)
+      temp = @contents[index1]
+      @contents[index1] = @contents[index2]
+      @contents[index2] = temp
+    end
+
+    def bubble_up(index)
+      parent_index = (index - 1) / 2 # watch out, integer division!
+      while index > 0 && @contents[index] > @contents[parent_index]
+        # if the node has a smaller value than its parent, swap these nodes
+        # to uphold the minheap invariant and update the index of the 'current'
+        # node. If the node is already at index 0, we can also stop because that
+        # is the root of the heap.
+        swap(index, parent_index)
+        index = parent_index
+        parent_index = (index - 1) / 2 # watch out, integer division!
+      end
+    end
+
+    def bubble_down(index)
+      least_valued_child_node = 0
+      while(true)
+        left_child_index = (2 * index) + 1
+        left_child_value = @contents[left_child_index]
+        if left_child_value.nil?
+          # This node has no children so it can't bubble down any further.
+          # We're done here!
+          return
+        end
+        # Determine which of the child nodes has the smallest value
+        right_child_index = left_child_index + 1
+        right_child_value = @contents[right_child_index]
+        if right_child_value.nil?
+          # node only has a left child
+          least_valued_child_node = left_child_value
+          least_valued_child_index = left_child_index
+        elsif right_child_value < left_child_value
+          least_valued_child_node = left_child_value
+          least_valued_child_index = left_child_index
+        else
+          least_valued_child_node = right_child_value
+          least_valued_child_index = right_child_index
+        end
+        if @contents[index] < least_valued_child_node
+          # No need to swap, the minheap invariant is already satisfied.
+          return
+        else
+          # at least one of the child node has a smaller value than the current
+          # node, swap current node with that child and update current node for
+          # if it might need to bubble down even further.
+          swap(index, least_valued_child_index)
+          index = least_valued_child_index
+        end
+      end
+    end
+  end
+end

--- a/spec/timers/priority_heap_spec.rb
+++ b/spec/timers/priority_heap_spec.rb
@@ -6,7 +6,7 @@
 RSpec.describe Timers::PriorityHeap do
   context "when empty" do 
     it "should return nil when the first element is requested" do
-      expect(subject.first).to be_nil
+      expect(subject.peek).to be_nil
     end
 
     it "should return nil when the first element is extracted" do
@@ -19,7 +19,7 @@ RSpec.describe Timers::PriorityHeap do
   end
 
   it "returns the same element after inserting a single element" do
-    subject.insert(1)
+    subject.push(1)
     expect(subject.size).to eq(1)
     expect(subject.pop).to eq(1)
     expect(subject.size).to be_zero
@@ -27,10 +27,11 @@ RSpec.describe Timers::PriorityHeap do
 
   it "should return inserted elements in ascending order no matter the insertion order" do
     (1..10).to_a.shuffle.each do |e|
-      subject.insert(e)
+      subject.push(e)
     end
 
     expect(subject.size).to eq(10)
+    expect(subject.peek).to eq(1)
 
     result = []
     10.times do

--- a/spec/timers/priority_heap_spec.rb
+++ b/spec/timers/priority_heap_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+#
+# This file is part of the "timers" project and released under the MIT license.
+#
+
+RSpec.describe Timers::PriorityHeap do
+  context "when empty" do 
+    it "should return nil when the first element is requested" do
+      expect(subject.first).to be_nil
+    end
+
+    it "should return nil when the first element is extracted" do
+      expect(subject.pop).to be_nil
+    end
+
+    it "should report its size as zero" do
+      expect(subject.size).to be_zero
+    end
+  end
+
+  it "returns the same element after inserting a single element" do
+    subject.insert(1)
+    expect(subject.size).to eq(1)
+    expect(subject.pop).to eq(1)
+    expect(subject.size).to be_zero
+  end
+
+  it "should return inserted elements in ascending order no matter the insertion order" do
+    (1..10).to_a.shuffle.each do |e|
+      subject.insert(e)
+    end
+
+    expect(subject.size).to eq(10)
+
+    result = []
+    10.times do
+      result << subject.pop
+    end
+
+    expect(result.size).to eq(10)
+    expect(subject.size).to be_zero
+    expect(result.sort).to eq(result)
+  end
+end


### PR DESCRIPTION
## Description
Refactors the implementation of the priority queue in `Timers::Events` to use a heap instead of an array, which offers nicer algorithmic runtimes. Resolves #73.

### Types of Changes
- Performance improvement.

### Testing
All existing tests still work, since I kept the interface of `Timers::Events` exactly the same. There is a new file with unit tests for the `PriorityHeap` class and I also added a new test to the `performance_spec.rb` file.  
