### PR TITLE
Heap validations

### DIFF
--- a/lib/timers/priority_heap.rb
+++ b/lib/timers/priority_heap.rb
@@ -94,7 +94,7 @@ module Timers
 
 		# Validate the heap invariant. Every element except the root must not be smaller than
     # its parent element. Note that it MAY be equal.
-		def validate!
+		def valid?
       # notice we skip index 0 on purpose, because it has no parent
       (1..(@contents.size - 1)).all? { |e| @contents[e] >= @contents[(e - 1) / 2] }
 		end

--- a/lib/timers/priority_heap.rb
+++ b/lib/timers/priority_heap.rb
@@ -87,30 +87,19 @@ module Timers
 			return self
 		end
 		
-		private
-		
-		# Validate the heap invariant.
-		def validate!(index = 0)
-			if value = @contents[index]
-				left_index = index*2 + 1
-				if left_value = @contents[left_index]
-					unless value < left_value
-						raise "Invalid left index from #{index}!"
-					end
-					
-					validate!(left_index)
-				end
-				
-				right_index = left_index + 1
-				if right_value = @contents[right_index]
-					unless value < right_value
-						raise "Invalid right index from #{index}!"
-					end
-					
-					validate!(right_index)
-				end
-			end
+    # Empties out the heap, discarding all elements
+		def clear!
+      @contents = []
+    end
+
+		# Validate the heap invariant. Every element except the root must not be smaller than
+    # its parent element. Note that it MAY be equal.
+		def validate!
+      # notice we skip index 0 on purpose, because it has no parent
+      (1..(@contents.size - 1)).all? { |e| @contents[e] >= @contents[(e - 1) / 2] }
 		end
+
+		private
 		
 		def swap(i, j)
 			@contents[i], @contents[j] = @contents[j], @contents[i]

--- a/spec/timers/priority_heap_spec.rb
+++ b/spec/timers/priority_heap_spec.rb
@@ -60,4 +60,39 @@ RSpec.describe Timers::PriorityHeap do
 		expect(subject.size).to be_zero
 		expect(result.sort).to eq(result)
 	end
+
+  context "maintaining the heap invariant" do
+    it "for empty heaps" do
+      expect(subject.validate!).to be true
+    end
+
+    it "for heap of size 1" do
+      subject.push(123)
+      expect(subject.validate!).to be true
+    end
+    # Exhaustive testing of all permutations of [1..6]
+    it "for all permutations of size 6" do
+      [1,2,3,4,5,6].permutation do |arr|
+        subject.clear!
+        arr.each { |e| subject.push(e) }
+        expect(subject.validate!).to be true
+      end
+    end
+
+    # A few examples with more elements (but not ALL permutations)
+    it "for larger amounts of values" do
+      5.times do
+        subject.clear!
+        (1..1000).to_a.shuffle.each { |e| subject.push(e) }
+        expect(subject.validate!).to be true
+      end
+    end
+
+    # What if we insert several of the same item along with others?
+    it "with several elements of the same value" do
+      test_values = (1..10).to_a + [4] * 5
+      test_values.each { |e| subject.push(e) }
+      expect(subject.validate!).to be true
+    end
+  end
 end

--- a/spec/timers/priority_heap_spec.rb
+++ b/spec/timers/priority_heap_spec.rb
@@ -63,19 +63,19 @@ RSpec.describe Timers::PriorityHeap do
 
   context "maintaining the heap invariant" do
     it "for empty heaps" do
-      expect(subject.validate!).to be true
+      expect(subject).to be_valid
     end
 
     it "for heap of size 1" do
       subject.push(123)
-      expect(subject.validate!).to be true
+      expect(subject).to be_valid
     end
     # Exhaustive testing of all permutations of [1..6]
     it "for all permutations of size 6" do
       [1,2,3,4,5,6].permutation do |arr|
         subject.clear!
         arr.each { |e| subject.push(e) }
-        expect(subject.validate!).to be true
+        expect(subject).to be_valid
       end
     end
 
@@ -84,7 +84,7 @@ RSpec.describe Timers::PriorityHeap do
       5.times do
         subject.clear!
         (1..1000).to_a.shuffle.each { |e| subject.push(e) }
-        expect(subject.validate!).to be true
+        expect(subject).to be_valid
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe Timers::PriorityHeap do
     it "with several elements of the same value" do
       test_values = (1..10).to_a + [4] * 5
       test_values.each { |e| subject.push(e) }
-      expect(subject.validate!).to be true
+      expect(subject).to be_valid
     end
   end
 end


### PR DESCRIPTION
## Description
As discussed on slack, this PR adds some tests for validating several kinds of heaps. It also catches a bug in the original validate function, which would fail on inputs containing several elements with the same value (ie it used `<` where it should have used `<=`). I also rewrote the validate function to be shorter but equivalent, except that it now returns true/false instead of raising an exception as that plays better with rspec.
