### PR TITLE
Huge performance improvements, using d_heap gem.

### DIFF
--- a/lib/timers/group.rb
+++ b/lib/timers/group.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 # Copyright, 2018, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -96,7 +96,7 @@ module Timers
 					sleep interval
 				end
 			end
-			
+
 			fire
 		end
 

--- a/spec/timers/performance_spec.rb
+++ b/spec/timers/performance_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Timers::Group do
 
 		it "runs efficiently" do
 			result = []
-			range = (1..500)
+			range = (1..5000)
 			duration = 2.0
 
 			total = 0
@@ -87,10 +87,10 @@ RSpec.describe Timers::Group do
 			expect(subject.current_offset).to be_within(20).percent_of(duration)
 		end
 	end
-	
+
 	it "runs efficiently at high volume" do
 		results = []
-		range = (1..300)
+		range = (1..3000)
 		groups = (1..20)
 		duration = 11
 

--- a/timers.gemspec
+++ b/timers.gemspec
@@ -4,17 +4,18 @@ require_relative "lib/timers/version"
 Gem::Specification.new do |spec|
 	spec.name = "timers"
 	spec.version = Timers::VERSION
-	
+
 	spec.summary = "Pure Ruby one-shot and periodic timers."
 	spec.authors = ["Samuel Williams", "Tony Arcieri"]
 	spec.license = "MIT"
-	
+
 	spec.homepage = "https://github.com/socketry/timers"
-	
+
 	spec.files = Dir.glob('{lib}/**/*', File::FNM_DOTMATCH, base: __dir__)
-	
+
 	# spec.required_ruby_version = ">= 2.5"
-	
+	spec.add_dependency "d_heap"
+
 	spec.add_development_dependency "bundler"
 	spec.add_development_dependency "covered"
 	spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
_n.b. this is more request for comments (with code) than a draft PR._

Over the holidays, I looked into making a PR to use a min-heap priority queue.  But then I got bogged down in benchmarks and C extensions and SIMD vector intrinsics for over a month, and I totally forgot about my `timers` branches! Just today I thought I'd look into cleaning it up for a PR and I saw @WJWH beat me to it with #74! 😆👍🏻  #74 does some of what I was trying to do, without using a C extension.

_I'll need to rebase my changes on `master` to see how they compare against the new implementation and with the new performance specs. Apologies for any gratuitous formatting changes that accidentally sneaked into my branches. I intend to remove those._

## Description

Before implementing my min-heap, I wanted to get a fair comparison with the existing algorithm by refactoring it to use `Array#bsearch_index` [(in my `nevans:perf-bsearch` branch)](https://github.com/socketry/timers/compare/master...nevans:perf-bsearch). This is a _huge_ improvement.  Although it's still technically `O(n)` for push—`Array#insert` may need to memcpy a significant portion of the array—`memcpy` is so incredibly fast on modern hardware that the comparisons wind up dominating for N < 10000.  Anything to avoid jumping from C code into ruby code during the comparisons sped it up. E.g. using `alias to_f time` instead of `def to_f; @time; end` is a significant part of this improvement. Combined with `O(1)` pop, and [this implementation](https://github.com/socketry/timers/compare/master...nevans:perf-bsearch) is fantastic for smaller queues.

Then I attempted [a pure ruby heap](https://github.com/socketry/timers/compare/master...nevans:perf-heap-rb). @WJWH did it better in #74, so I won't say much about my version.  :)  While I did achieve an improvement over the original, I was _deeply disappointed_ in the performance (for N<50k) compared to the much simpler `Array#bsearch_index` algorithm.  The pure ruby heap I use in my `d_heap` benchmarks is faster than the version in that branch.

So then I looked into C extensions. I did find a couple of other priority queue ruby gems, one of them used the C++ STL `std::priority_queue`, but I wound up getting a bit obsessive about this and wrote my own: [d_heap], which implements a [d-ary heap](https://en.wikipedia.org/wiki/D-ary_heap). If you look at the [benchmarks in the README](https://github.com/nevans/d_heap#benchmarks), I think you'll get a notion of the relative scale between a pure ruby min heap, `Array#bsearch`, and `d_heap`.  `d_heap` runs considerably faster for every size queue. It's even faster than the priority_queue_cxx gem's C++ `std::priority_queue` implementation (at least on my system).

Both go and libev use a 4heap, but I was surprised to find that—at least with my benchmarks on modern hardware and with modern compilers—d=4 was not the ideal d value. I chalk this up to CPU branch prediction and `gcc -O3` loop unrolling (etc). On my system, I discovered (with AVX2 enabled) d=12 was generally fastest. But I need to do more benchmarks on other systems to discover an appropriate default.

[d_heap]: https://github.com/nevans/d_heap

[d_heap] is still missing a few bits before it's production ready. At the very least:
- [ ] shrink the C array when items are popped!!!
- [ ] a simple JRuby version using `java.util.PriorityQueue`.
- [ ] a fallback pure ruby version for systems which can't compile the C extension
- [ ] test more hardware for a generically suitable default `d`
- [ ] test 32-bit hardware for compatibility

I went a bit overboard learning about SIMD vectors and playing with SSE/AVX2/AVX512 and C macros in one of my unreleased branches. I did push it to even faster performance than `gcc's -O3` with `-funroll-loops`, etc, but I completely forgot about cleaning it all up for production release! 😆

### Types of Changes

- Performance improvement.

### Testing

- [x] I added tests for my changes
  - [x] extensive tests in the [d_heap] gem
  - [x] increased numbers on existing perf spec to clarify differences
  - [ ] intended to add a couple of specs similar to 92b2a81d to simulate realistic timer scenarios
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.

### Other variations to consider

`go` is very smart about lazily updating their timers heap, keeping a counter of all deleted or updated timers and flagging the individual timers.  If you delete/adjust timers lazily, then most timers can be rescheduled before they incur any cancellation + re-insertion costs.

One variation I intended to benchmark but never got around to: use the `bsearch` implementation for smaller queues, but dynamically converting to a min-heap when it gets large.  A sorted array already satisfies the heap property, so the only tricky part is tuning when to `sort!` and convert back to `bsearch` if/when the queue shrinks and stays small.

Another variation relies on 1) all timers with the same timeout can be handled with a FIFO, 2) CRuby's `Array#shift` is special-cased to allow `O(1)` queue behavior, and 3) the assumption that most timers will have integer timeouts of less than 5 minutes.  So we could create an Array of timeouts => timers, e.g. `Array.new(5 * 60) { [] }`, with two additional priority queues: the first for any other timers (e.g. deadline-based, float duration, or longer than 5 minutes), and the second would select the minimum. The merged priority queue would hold no more than 301 items, so `bsearch` + `insert` would be super fast (`d_heap` would still be 4x faster). Any integer timeout < 5 minutes could be effectively `O(1)`.

Another variation (I saw this in a python library, I forget which one) relies on the assumption that most timers are timeouts that we expect to be canceled (the operation will succeed before timing out).  To that end, maintain both "near" and "far" collections.  The "near" collection can be a min-heap, but the far collection is simply a `Set` or a `Map` with an ivar for "far_deadline". Whenever the "far_deadline" is "near", the map will be scanned (`O(n)`) for anything below the newly extended "far_deadline".  The idea here is to get O(1) cancellation for most timers, because canceling timers is more common than firing them.

But IMO the two previous variations are both pointing towards various sorts of timing wheels.  The Linux process scheduler uses one version with reduced precision based on how far away the deadline is when it's scheduled.  And [kafka](https://www.confluent.io/blog/apache-kafka-purgatory-hierarchical-timing-wheels/) uses hierarchical timing wheels. With timing wheels, we could effectively achieve O(1) for push, pop, and cancel. But timing wheels are conceptually much more complex than a simple min-heap.  I figured, if `go`s timers can get by with a minheap, it's probably fine to just start there.