### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,8 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
-        
+          - "3.2"
+ 
         experimental: [false]
         
         include:


### PR DESCRIPTION
Adds Ruby 3.2 to the CI matrix.  As Ruby 3.2 has been released, this gem should test against this new version of Ruby.

## Types of Changes

- Maintenance.

## Contribution

- [X] I tested my changes locally.
- [X] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
