### PR TITLE
Timer#fire: return result of block

### DIFF
--- a/lib/timers/timer.rb
+++ b/lib/timers/timer.rb
@@ -6,6 +6,7 @@
 # Copyright, 2014, by Utenmiki.
 # Copyright, 2014, by Lin Jen-Shin.
 # Copyright, 2017, by Vít Ondruch.
+# Copyright, 2025, by Patrik Wenger.
 
 module Timers
 	# An individual timer set to fire a given proc at a given time. A timer is
@@ -102,9 +103,9 @@ module Timers
 				@offset = offset
 			end
 			
-			@block.call(offset, self)
-			
+			result = @block.call(offset, self)
 			cancel unless recurring
+			result
 		end
 		
 		alias call fire

--- a/test/timers/timer.rb
+++ b/test/timers/timer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Patrik Wenger.
+
+require 'timers/timer'
+
+describe Timers::Timer do
+	let(:group) {Timers::Group.new}
+	
+	it "should return the block value when fired" do
+		timer  = group.after(10) {:foo}
+		result = timer.fire
+
+		expect(result).to be == :foo
+	end
+end


### PR DESCRIPTION
In tests I found it useful to manually fire a timer and was suprised it didn't return the block result. Instead, it was exposing a `Set` from the `Group` as the return value. With this change it returns the block result. 